### PR TITLE
Fix null check on WidgetsBinding.instance

### DIFF
--- a/lib/declarative_refresh_indicator.dart
+++ b/lib/declarative_refresh_indicator.dart
@@ -130,7 +130,7 @@ class _DeclarativeRefreshIndicatorState
   void initState() {
     super.initState();
     // If the indicator should be shown initially, show it.
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.refreshing) _show();
     });
   }


### PR DESCRIPTION
In the flutter beta channel and newer the instance is non-nullable (https://github.com/flutter/flutter/blob/beta/packages/flutter/lib/src/widgets/binding.dart#L306).